### PR TITLE
tell `swift build` to build tests if it can

### DIFF
--- a/src/SwiftTools.ts
+++ b/src/SwiftTools.ts
@@ -21,7 +21,7 @@ export function buildPackage(swiftBinPath: string, pkgPath: string, options: str
     stdout = null
     stderr = null
     error = null
-    const sb = cp.spawn(swiftBinPath, ["build"], { cwd: pkgPath });
+    const sb = cp.spawn(swiftBinPath, ["build", "--build-tests"], { cwd: pkgPath });
     sb.stdout.on('data', (data) => {
         stdout += data
         dumpInConsole("" + data)


### PR DESCRIPTION
If the project open in VSCode has Unit Tests, this change will make VSCode build those tests along with the other sources.  If the project doesn't have tests, this change will have no effect. 

The one potential downside of this change is that it makes it harder for a developer to ignore a broken test while they're trying to work on something else.  In that case, they could just rename the project's `Tests` directory temporarily until they are ready to start working on the tests again.

Note that this change doesn't cause VSCode to Run the tests - it just builds them.  In order to run them, the `launch.json` file will need to be changed so the `program` points to the `.xctest` bundle. 