### PR TITLE
Swift 4 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ===
 
+Next version
+---
+* basic support for Swift 4. (issue #38)
+
 2.0.20170209
 ---
 * make a sourcekite docker image and add a new experimental setting "swift.path.sourcekiteDockerMode" for easier adoption for Linux users (issue: #26) (MacOS users do not need to update to this version in that there is no other additions in this version)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/jinmingjian/sde"
   },
   "engines": {
-    "vscode": "^1.8.0"
+    "vscode": "^1.16.0"
   },
   "categories": [
     "Languages"

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -44,7 +44,7 @@ export function initializeModuleMeta() {
 		}
 		//TODO more here
 		const pkgDesc = JSON.parse(data)
-		for (const m of <Object[]>pkgDesc['modules']) {
+		for (const m of <Object[]>pkgDesc['modules'] || pkgDesc['targets']) {
 			const mn = m['name']
 			const mp = m['path']
 			const ss = <string[]>m['sources']
@@ -87,7 +87,7 @@ export function getAllSourcePaths(srcPath: string): string[] {
 }
 
 // After the server has started the client sends an initilize request. The server receives
-// in the passed params the rootPath of the workspace plus the client capabilites. 
+// in the passed params the rootPath of the workspace plus the client capabilites.
 export let workspaceRoot: string;
 export let isTracingOn: boolean;
 connection.onInitialize((params: InitializeParams, cancellationToken): InitializeResult => {
@@ -148,7 +148,7 @@ connection.onDidChangeConfiguration((change) => {
 	swiftDiverBinPath = sdeSettings.path.swift_driver_bin
 	shellPath = sdeSettings.path.shell
 
-	trace(`-->onDidChangeConfiguration tracing: 
+	trace(`-->onDidChangeConfiguration tracing:
 	    swiftDiverBinPath=[${swiftDiverBinPath}],
 		shellPath=[${shellPath}]`)
 
@@ -364,7 +364,7 @@ async function extractHoverHelp(cursorInfo: Object): Promise<MarkedString[]> {
 		return rt
 	}
 	//TODO wait vscode to support full html rendering...
-	//stripe all sub elements 
+	//stripe all sub elements
 	function stripeOutTags(str) {
 		return str.replace(/(<.[^(><.)]+>)/g, (m, c) => '')
 	}
@@ -506,7 +506,7 @@ export function getShellExecPath() {
 /**
  * NOTE:
  * now the SDE only support the convention based build
- * 
+ *
  * TODO: to use build yaml?
  */
 let argsImportPaths: string[] = null

--- a/src/server/sourcekites.ts
+++ b/src/server/sourcekites.ts
@@ -128,13 +128,12 @@ class SourcekiteResponseHandler {
 
 }
 
-let reqCount = 0 //FIXME 
+let reqCount = 0 //FIXME
 
 type RequestType = "codecomplete" | "cursorinfo" | "demangle" | "editor.open" | "editor.formattext"
 
-//FIXME generic for future
-function typedResponse(request: string, requestType: RequestType,
-    extraState: any = null): Promise<{}> {
+function typedResponse<T>(request: string, requestType: RequestType,
+    extraState: any = null): Promise<T> {
     server.trace('to write request: ', request)
     const rid = reqCount++
     skProtocolProcess.stdin.write(rid + "\n")
@@ -182,7 +181,7 @@ function request(
   key.sourcefile: "${srcPath}",
   key.offset: ${offset},
   key.compilerargs: ${compilerargs},
-  key.sourcetext: ${srcText} 
+  key.sourcetext: ${srcText}
 }
 
 `


### PR DESCRIPTION
Thank you very much for your great project!
Currently SDE doesn't work for Swift 4 projects as stated in #38.

Some dependencies have released updates, which broke the current master branch. I bumped the vscode engine dependency to `^1.16.0` as it is required by the language client (see Microsoft/vscode-languageserver-node#248).
As a bonus, the implicit typescript update allowed me to remove a fixme and use generics.

Swift 4 probably renamed Swift 3.1's `modules` property to `targets`, when running `swift package describe --type json` (credits to @ainopara). Now SDE will simply fallback to `targets`, temporarily eliminating the crash. In the long run, there should be a better error message (e.g. "Swift version not supported.").

After all I haven't tested a lot (e.g. regression errors at runtime through dependency upgrades), but the basic functionality is now restored for Swift 4 on Macs (I'm not sure about Linux support though).

For the ones of you, who trust me and really need Swift 4 support as soon as possible, I uploaded the current vscode extension. If you need help for installing it, here is the [the official installation guide](https://code.visualstudio.com/docs/editor/extension-gallery#_install-from-a-vsix).
[sde-2.0.20171010.vsix.zip](https://github.com/jinmingjian/sde/files/1373085/sde-2.0.20171010.vsix.zip)